### PR TITLE
fix stable release name, fixes #2

### DIFF
--- a/distrobadges.nim
+++ b/distrobadges.nim
@@ -34,7 +34,7 @@ const
   distros: seq[DistroMetadata] = @[
     ("debian", "stable", "dpkg",
     "https://packages.$distro.org/$flavour/$pname",
-    "http://cdn-fastly.deb.debian.org/debian/dists/wheezy/main/binary-amd64/Packages.bz2"),
+    "http://cdn-fastly.deb.debian.org/debian/dists/stable/main/binary-amd64/Packages.xz"),
     ("debian", "testing", "dpkg",
     "https://packages.$distro.org/$flavour/$pname",
     "http://cdn-fastly.deb.debian.org/debian/dists/testing/main/binary-amd64/Packages.xz"),


### PR DESCRIPTION
the stable release hasn't been wheezy for a long time now, and besides there's no reason to use the codename there...