### PR TITLE
Fix AsciiDoc example syntax on start page

### DIFF
--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -142,7 +142,7 @@
 
     <p>AsciiDoc</p>
     <pre>
-    image:${baseurl}/badges/${distro}/${flavour}/${pname}/version.svg", link="${pkg_directory_url}"]
+    image:${baseurl}/badges/${distro}/${flavour}/${pname}/version.svg[link="${pkg_directory_url}"]
     </pre>
 
     <p>Markdown</p>


### PR DESCRIPTION
Reference: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#images

This is actually untested, but the unbalanced square brackets jumped into my eye.